### PR TITLE
fix: missing 'self' reference

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -507,7 +507,7 @@ function DialogKey:EnumerateGossips()
     if QuestFrameGreetingPanel and QuestFrameGreetingPanel.titleButtonPool then
         --- @type FramePool<Button, QuestTitleButtonTemplate>
         local pool = QuestFrameGreetingPanel.titleButtonPool;
-        for tab in (pool.EnumerateActive()) do
+        for tab in (pool:EnumerateActive()) do
             if tab:GetObjectType() == "Button" then
                 table.insert(self.frames, tab)
             end


### PR DESCRIPTION
It looks like a `self` reference was dropped in [some recent changes](https://github.com/NumyAddon/DialogKey_Numy/commit/4e7d3d94f35bb0f5a6e93eac860406b0d8458a5e#diff-cee6f7ace765d4b3e8274806fb658676b5f550810b495d8987ea30ab1121ea73R511), this should add it back in.

![image](https://github.com/user-attachments/assets/8d568349-0705-4988-b155-aaf978b86369)

```Message: Interface/AddOns/Blizzard_SharedXMLBase/Pools.lua:214: attempt to index local 'self' (a nil value)
Time: Fri Nov 22 21:31:50 2024
Count: 1
Stack: Interface/AddOns/Blizzard_SharedXMLBase/Pools.lua:214: attempt to index local 'self' (a nil value)
[string "@Interface/AddOns/Blizzard_SharedXMLBase/Pools.lua"]:214: in function <Interface/AddOns/Blizzard_SharedXMLBase/Pools.lua:213>
[string "=(tail call)"]: ?
[string "@Interface/AddOns/DialogKey_Numy/main.lua"]:510: in function `EnumerateGossips'
[string "@Interface/AddOns/DialogKey_Numy/main.lua"]:96: in function <Interface/AddOns/DialogKey_Numy/main.lua:96>

Locals: self = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index local 'self' (a nil value)"
```